### PR TITLE
Fix bayonet failing to install

### DIFF
--- a/bayonet.gemspec
+++ b/bayonet.gemspec
@@ -9,10 +9,6 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Thomas Ritter"]
   spec.email         = ["ritter.thomas@gmail.com"]
 
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com' to prevent pushes to rubygems.org, or delete to allow pushes to any server."
-  end
-
   spec.summary       = %q{Bayonet is a Microsoft Excel write-only gem that reads and produces XLSX files.}
   spec.description   = %q{Bayonet is a Microsoft Excel write-only gem that reads and produces XLSX files. It's strength lies in the fact that it's able to open bigger Excel files (even with macros!) -- and write cells without touching the rest of the Excel file.}
   spec.homepage      = "https://github.com/nethad/bayonet"


### PR DESCRIPTION
On our CI server bayonet fails to install from nethad/bayonet because of this error:

```
The gemspec at /home/runner/blue-space/vendor/bundle/ruby/2.3.0/bundler/gems/bayonet-ec0e3d4d7b1f/bayonet.gemspec is not valid. The validation error was '"FIXME" or "TODO" is not a description'
Could not find bayonet-0.1.0 in any of the sources
Run `bundle install` to install missing gems.
```

Getting rid of this TODO line fixes the issue.
